### PR TITLE
Add Vercel SPA rewrite config

### DIFF
--- a/server/vercel.json
+++ b/server/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/index.html" }]
+}


### PR DESCRIPTION
## Summary
- add `server/vercel.json` for SPA history fallback on Vercel
- rewrite all routes to `/index.html` so direct access/refresh works

## Why
This Vue app uses history mode router, so Vercel needs a rewrite rule to avoid 404 on nested routes.