### PR TITLE
Remove hits badge from footer

### DIFF
--- a/server/src/components/FooterVue.vue
+++ b/server/src/components/FooterVue.vue
@@ -7,10 +7,6 @@
     <a href="https://github.com/ssafy-attendance/Server"
       ><img src="@/assets/github.png" alt="github"
     /></a>
-    <img
-      id="hits"
-      src="https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fssafy-attendance.site&count_bg=%231BB0E7&title_bg=%231BB0E7&icon=&icon_color=%23E7E7E7&title=%EC%98%A4%EB%8A%98+%2F+%EC%A0%84%EC%B2%B4&edge_flat=false"
-    />
   </footer>
 </template>
 
@@ -35,11 +31,6 @@ a {
 h2 {
   font-size: 1.2rem;
   font-weight: 800;
-}
-
-#hits {
-  width: 150px;
-  padding: 1.5rem;
 }
 
 img {


### PR DESCRIPTION
## Summary
- remove the hits counter badge image from footer
- remove unused `#hits` styles in `FooterVue.vue`

## Why
Hide the public hit counter from the homepage footer while keeping existing footer links/text.